### PR TITLE
Add hints towards flash protection to welding masks

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/welding.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/welding.yml
@@ -28,7 +28,7 @@
   parent: WeldingMaskBase
   id: ClothingHeadHatWelding
   name: welding mask
-  description: A head-mounted face cover designed to protect the wearer completely from space-arc eye.
+  description: A head-mounted face cover designed to protect the wearer completely from space-arc eye, also provides protection from bright flashes.
   components:
   - type: Sprite
     sprite: Clothing/Head/Welding/welding.rsi
@@ -44,7 +44,7 @@
   parent: WeldingMaskBase
   id: ClothingHeadHatWeldingMaskFlame
   name: flame welding mask
-  description: A painted welding helmet, this one has flames on it.
+  description: A painted welding helmet, this one has flames on it, also provides protection from bright flashes.
   components:
   - type: Sprite
     sprite: Clothing/Head/Welding/flame_welding_mask.rsi
@@ -55,7 +55,7 @@
   parent: WeldingMaskBase
   id: ClothingHeadHatWeldingMaskFlameBlue
   name: blue-flame welding mask
-  description: A painted welding helmet, this one has blue flames on it.
+  description: A painted welding helmet, this one has blue flames on it, also provides protection from bright flashes.
   components:
   - type: Sprite
     sprite: Clothing/Head/Welding/blue_flame_welding_mask.rsi
@@ -66,7 +66,7 @@
   parent: WeldingMaskBase
   id: ClothingHeadHatWeldingMaskPainted
   name: painted welding mask
-  description: A welding helmet, painted in crimson.
+  description: A welding helmet, painted in crimson, also provides protection from bright flashes.
   components:
   - type: Sprite
     sprite: Clothing/Head/Welding/paintedwelding.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added text to the description of welding masks "also provides protection from bright flashes."

## Why / Balance
I spoke to a few new players none of which knew that welding masks even provided flash protection, even after a week of playtime.

## Technical details
Made changes to welding.yml adding ", also provides protection from bright flashes." to all description text

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/18996d2a-3717-4a4c-a235-98e04f086dfa)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

🆑 
Welding mask description now hints towards flash protection